### PR TITLE
Add email confirmation endpoint

### DIFF
--- a/data/email_db.py
+++ b/data/email_db.py
@@ -1,0 +1,12 @@
+EMAILS = {
+    "12345": "user12345@example.com",
+    "23456": "user23456@example.com",
+    "34567": "user34567@example.com",
+    "45678": "user45678@example.com",
+    "56789": "user56789@example.com",
+    "67890": "user67890@example.com",
+    "78901": "user78901@example.com",
+    "89012": "user89012@example.com",
+    "90123": "user90123@example.com",
+    "01234": "user01234@example.com",
+}

--- a/main.py
+++ b/main.py
@@ -4,11 +4,16 @@ from data.accounts_db import ACCOUNTS
 from data.balance_db import BALANCES
 from data.usage_db import USAGES
 from data.invoice_db import INVOICES
+from data.email_db import EMAILS
 
 app = FastAPI()
 
 class AccountRequest(BaseModel):
     account_number: str
+
+
+class EmailConfirmRequest(AccountRequest):
+    email: str
 
 @app.post("/validate/")
 def validate_account(data: dict):
@@ -39,3 +44,19 @@ def get_invoice(data: AccountRequest):
     if invoice:
         return {"status": "success", "invoice": invoice}
     return {"status": "failure", "message": "Invoice not found."}
+
+
+@app.post("/email/")
+def get_email(data: AccountRequest):
+    email = EMAILS.get(data.account_number)
+    if email:
+        return {"status": "success", "email": email}
+    return {"status": "failure", "message": "Email not found."}
+
+
+@app.post("/confirm_email/")
+def confirm_email(data: EmailConfirmRequest):
+    stored = EMAILS.get(data.account_number)
+    if stored and stored.lower() == data.email.lower():
+        return {"status": "success", "message": "Email confirmed."}
+    return {"status": "failure", "message": "Email does not match."}


### PR DESCRIPTION
## Summary
- store predefined synthetic emails for each account
- extend API with `/confirm_email/` to verify account email

## Testing
- `python -m py_compile main.py data/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684237dd9a208325b5d22186b1d93502